### PR TITLE
Implement session-based context reuse

### DIFF
--- a/server.js
+++ b/server.js
@@ -153,8 +153,16 @@ if (cluster.isMaster) {
         const startTime = Date.now();
         
         // Basit test için scraper'ı import et
-        const { scrapeSinglePage } = require('./scraper');
-        const result = await scrapeSinglePage(url, true);
+        const { scrapeSinglePage, getSessionManager, initWebshareProxies, getWebshareManager } = require('./scraper');
+
+        await initWebshareProxies();
+        const sm = getSessionManager();
+        const wm = getWebshareManager();
+        const proxy = wm.getNextProxy();
+        const sessionId = await sm.createSession(proxy, 'us');
+        const session = sm.getSession(sessionId);
+        const result = await scrapeSinglePage(url, session);
+        await sm.removeSession(sessionId);
         
         const duration = Date.now() - startTime;
         


### PR DESCRIPTION
## Summary
- manage contexts per session using browser pool
- update scraper to use `session.context`
- adapt server and strategy builder to new scraper interface

## Testing
- `node -e "require('./scraper');"` *(fails: Cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_684d981698d48323b8b59ca172789e75